### PR TITLE
Add browser-based authentication for reverse proxy SSO

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
 
     <application
         android:allowBackup="true"
+        android:hasFragileUserData="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,13 @@
             android:screenOrientation="portrait"
             android:theme="@style/Theme.ComfyChair.Fullscreen" />
 
+        <!-- WebViewAuthActivity - Browser-based SSO/OAuth authentication -->
+        <activity
+            android:name=".WebViewAuthActivity"
+            android:exported="false"
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize" />
+
         <!-- MaskEditorActivity - Fullscreen inpainting mask editor -->
         <activity
             android:name=".MaskEditorActivity"

--- a/app/src/main/java/sh/hnet/comfychair/AuthInterceptor.kt
+++ b/app/src/main/java/sh/hnet/comfychair/AuthInterceptor.kt
@@ -7,7 +7,10 @@ import sh.hnet.comfychair.model.AuthCredentials
 
 /**
  * OkHttp interceptor that adds Authorization headers to requests.
- * Supports HTTP Basic Auth and Bearer token authentication.
+ * Supports HTTP Basic Auth, Bearer token, and Cookie authentication.
+ *
+ * For Cookie auth (browser SSO), detects session expiry via 401/403 responses
+ * or redirects to auth domains, and notifies via [onSessionExpired] callback.
  */
 class AuthInterceptor(
     credentials: AuthCredentials = AuthCredentials.None
@@ -16,12 +19,22 @@ class AuthInterceptor(
     @Volatile
     private var currentCredentials: AuthCredentials = credentials
 
+    /** Called when a cookie-based session appears expired (401/403 or auth redirect). */
+    @Volatile
+    var onSessionExpired: (() -> Unit)? = null
+
+    /** Prevent firing the callback multiple times before re-auth completes. */
+    @Volatile
+    private var sessionExpiredFired = false
+
     /**
      * Update the credentials used for authentication.
      * Thread-safe - can be called from any thread.
      */
     fun setCredentials(newCredentials: AuthCredentials) {
         currentCredentials = newCredentials
+        // Reset expiry flag when new credentials are set (re-auth completed)
+        sessionExpiredFired = false
     }
 
     /**
@@ -32,20 +45,39 @@ class AuthInterceptor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
 
-        val authHeader = when (val creds = currentCredentials) {
-            is AuthCredentials.None -> null
-            is AuthCredentials.Basic -> Credentials.basic(creds.username, creds.password)
-            is AuthCredentials.Bearer -> "Bearer ${creds.token}"
-        }
-
-        val newRequest = if (authHeader != null) {
-            originalRequest.newBuilder()
-                .header("Authorization", authHeader)
+        val newRequest = when (val creds = currentCredentials) {
+            is AuthCredentials.None -> originalRequest
+            is AuthCredentials.Basic -> originalRequest.newBuilder()
+                .header("Authorization", Credentials.basic(creds.username, creds.password))
                 .build()
-        } else {
-            originalRequest
+            is AuthCredentials.Bearer -> originalRequest.newBuilder()
+                .header("Authorization", "Bearer ${creds.token}")
+                .build()
+            is AuthCredentials.Cookie -> originalRequest.newBuilder()
+                .header("Cookie", creds.cookies)
+                .build()
         }
 
-        return chain.proceed(newRequest)
+        val response = chain.proceed(newRequest)
+
+        // Detect session expiry for cookie-based auth
+        if (currentCredentials is AuthCredentials.Cookie && !sessionExpiredFired) {
+            val expired = when {
+                response.code == 401 || response.code == 403 -> true
+                // Authentik/OAuth redirects: 302 to a different host (auth domain)
+                response.isRedirect -> {
+                    val location = response.header("Location")
+                    val requestHost = originalRequest.url.host
+                    location != null && !location.contains(requestHost, ignoreCase = true)
+                }
+                else -> false
+            }
+            if (expired) {
+                sessionExpiredFired = true
+                onSessionExpired?.invoke()
+            }
+        }
+
+        return response
     }
 }

--- a/app/src/main/java/sh/hnet/comfychair/ComfyUIClient.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ComfyUIClient.kt
@@ -56,7 +56,8 @@ class ComfyUIClient(
     }
 
     // Auth interceptor for adding Authorization headers
-    internal val authInterceptor = AuthInterceptor(credentials)
+    /** Auth interceptor — exposed so ConnectionManager can wire the session-expired callback. */
+    val authInterceptor = AuthInterceptor(credentials)
 
     // OkHttpClient for HTTP requests - short timeouts are fine
     private val httpClient = SelfSignedCertHelper.configureToAcceptSelfSigned(

--- a/app/src/main/java/sh/hnet/comfychair/ComfyUIClient.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ComfyUIClient.kt
@@ -56,7 +56,7 @@ class ComfyUIClient(
     }
 
     // Auth interceptor for adding Authorization headers
-    private val authInterceptor = AuthInterceptor(credentials)
+    internal val authInterceptor = AuthInterceptor(credentials)
 
     // OkHttpClient for HTTP requests - short timeouts are fine
     private val httpClient = SelfSignedCertHelper.configureToAcceptSelfSigned(

--- a/app/src/main/java/sh/hnet/comfychair/MainContainerActivity.kt
+++ b/app/src/main/java/sh/hnet/comfychair/MainContainerActivity.kt
@@ -1,5 +1,6 @@
 package sh.hnet.comfychair
 
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -8,10 +9,16 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import sh.hnet.comfychair.connection.ConnectionState
 import kotlinx.coroutines.runBlocking
 import sh.hnet.comfychair.cache.MediaCache
 import sh.hnet.comfychair.cache.MediaStateHolder
@@ -44,6 +51,53 @@ class MainContainerActivity : ComponentActivity() {
     private val generationViewModel: GenerationViewModel by viewModels()
     private val imageToImageViewModel: ImageToImageViewModel by viewModels()
     private val imageToVideoViewModel: ImageToVideoViewModel by viewModels()
+
+    /**
+     * Handle manual re-auth result from WebView.
+     * The silent OkHttp refresh is now handled entirely in ConnectionManager —
+     * this callback is only for the fallback dialog-triggered manual re-auth.
+     */
+    private fun handleReAuthResult(resultCode: Int, data: Intent?) {
+        val cookies = data?.getStringExtra(WebViewAuthActivity.EXTRA_COOKIES) ?: ""
+        val authDomain = data?.getStringExtra(WebViewAuthActivity.EXTRA_AUTH_DOMAIN) ?: ""
+        val authDomainCookies = data?.getStringExtra(WebViewAuthActivity.EXTRA_AUTH_DOMAIN_COOKIES) ?: ""
+        if (resultCode == Activity.RESULT_OK && cookies.isNotEmpty()) {
+            // Success — update credentials (with auth domain for future silent refreshes) + reconnect
+            val newCreds = sh.hnet.comfychair.model.AuthCredentials.Cookie(
+                cookies = cookies,
+                authDomain = authDomain,
+                authDomainCookies = authDomainCookies
+            )
+            ConnectionManager.clientOrNull?.setCredentials(newCreds)
+            val serverId = ConnectionManager.currentServerId
+            if (serverId != null) {
+                sh.hnet.comfychair.storage.CredentialStorage(this)
+                    .saveCredentials(serverId, newCreds)
+            }
+            ConnectionManager.clearSessionExpired()
+            ConnectionManager.attemptSilentReconnect()
+        } else {
+            // User cancelled manual re-auth — log out
+            ConnectionManager.clearSessionExpired()
+            generationViewModel.logout()
+            finish()
+        }
+    }
+
+    // Manual re-auth — user-initiated from dialog (silent refresh now done via OkHttp in ConnectionManager)
+    private val manualReAuthLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result -> handleReAuthResult(result.resultCode, result.data) }
+
+    /** Launch WebView for re-auth. */
+    private fun launchReAuth(launcher: androidx.activity.result.ActivityResultLauncher<Intent>) {
+        val connState = ConnectionManager.connectionState.value
+        if (connState is ConnectionState.Connected) {
+            val serverUrl = buildServerUrl(connState.hostname, connState.port)
+            val intent = WebViewAuthActivity.createIntent(this, serverUrl, connState.hostname)
+            launcher.launch(intent)
+        }
+    }
 
     // Activity result launchers
     private val settingsLauncher = registerForActivityResult(
@@ -146,6 +200,36 @@ class MainContainerActivity : ComponentActivity() {
                     )
                 }
 
+                // Session expired — silent OkHttp refresh is attempted automatically by
+                // ConnectionManager. Show the manual re-auth dialog only when silent
+                // refresh has already failed (silentRefreshFailed == true).
+                val sessionExpired by ConnectionManager.sessionExpired.collectAsState()
+                val silentRefreshFailed by ConnectionManager.silentRefreshFailed.collectAsState()
+                if (sessionExpired && silentRefreshFailed) {
+                    // Silent OkHttp refresh failed — show manual re-auth dialog
+                    AlertDialog(
+                        onDismissRequest = { /* don't dismiss by tapping outside */ },
+                        title = { Text(stringResource(R.string.title_session_expired)) },
+                        text = { Text(stringResource(R.string.message_session_expired)) },
+                        confirmButton = {
+                            Button(onClick = {
+                                launchReAuth(manualReAuthLauncher)
+                            }) {
+                                Text(stringResource(R.string.button_reauthenticate))
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = {
+                                ConnectionManager.clearSessionExpired()
+                                generationViewModel.logout()
+                                finish()
+                            }) {
+                                Text(stringResource(R.string.button_logout))
+                            }
+                        }
+                    )
+                }
+
                 // Show connection alert dialog when connection fails
                 connectionAlertState?.let { state ->
                     ConnectionAlertDialog(
@@ -235,5 +319,14 @@ class MainContainerActivity : ComponentActivity() {
     override fun onDestroy() {
         super.onDestroy()
         // ViewModel handles cleanup automatically via onCleared()
+    }
+
+    private fun buildServerUrl(hostname: String, port: Int): String {
+        return when (port) {
+            443 -> "https://$hostname"
+            80 -> "http://$hostname"
+            8188 -> "http://$hostname:8188"
+            else -> "https://$hostname:$port"
+        }
     }
 }

--- a/app/src/main/java/sh/hnet/comfychair/MainContainerActivity.kt
+++ b/app/src/main/java/sh/hnet/comfychair/MainContainerActivity.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.runBlocking
 import sh.hnet.comfychair.cache.MediaCache
 import sh.hnet.comfychair.cache.MediaStateHolder
 import sh.hnet.comfychair.connection.ConnectionManager
+import sh.hnet.comfychair.connection.ConnectionState
 import sh.hnet.comfychair.navigation.MainRoute
 import sh.hnet.comfychair.repository.GalleryRepository
 import sh.hnet.comfychair.storage.AppSettings
@@ -35,6 +36,20 @@ import sh.hnet.comfychair.viewmodel.ImageToImageViewModel
 import sh.hnet.comfychair.viewmodel.ImageToVideoViewModel
 import sh.hnet.comfychair.viewmodel.TextToImageViewModel
 import sh.hnet.comfychair.viewmodel.TextToVideoViewModel
+
+/**
+ * Build a server URL with proper protocol detection.
+ * Port 443 → HTTPS, port 80 → HTTP, port 8188 → HTTP (ComfyUI default).
+ * Standard ports (80/443) omitted from URL. Others included.
+ */
+private fun buildServerUrl(hostname: String, port: Int): String {
+    return when (port) {
+        443 -> "https://$hostname"
+        80 -> "http://$hostname"
+        8188 -> "http://$hostname:8188"
+        else -> "https://$hostname:$port"
+    }
+}
 
 /**
  * Container activity that hosts the main navigation graph.
@@ -52,11 +67,7 @@ class MainContainerActivity : ComponentActivity() {
     private val imageToImageViewModel: ImageToImageViewModel by viewModels()
     private val imageToVideoViewModel: ImageToVideoViewModel by viewModels()
 
-    /**
-     * Handle manual re-auth result from WebView.
-     * The silent OkHttp refresh is now handled entirely in ConnectionManager —
-     * this callback is only for the fallback dialog-triggered manual re-auth.
-     */
+    /** Handle result from WebView re-auth (both silent-refresh-failed and manual). */
     private fun handleReAuthResult(resultCode: Int, data: Intent?) {
         val cookies = data?.getStringExtra(WebViewAuthActivity.EXTRA_COOKIES) ?: ""
         val authDomain = data?.getStringExtra(WebViewAuthActivity.EXTRA_AUTH_DOMAIN) ?: ""
@@ -307,6 +318,7 @@ class MainContainerActivity : ComponentActivity() {
         // Only attempt reconnection if generating (need the connection)
         // Otherwise, connection will be established on-demand when user taps Generate
         if (!AppSettings.isOfflineMode(this) && isGenerating) {
+            ConnectionManager.clearSessionExpired()
             ConnectionManager.attemptSilentReconnect()
         }
 

--- a/app/src/main/java/sh/hnet/comfychair/SelfSignedCertHelper.kt
+++ b/app/src/main/java/sh/hnet/comfychair/SelfSignedCertHelper.kt
@@ -1,9 +1,12 @@
 package sh.hnet.comfychair
 
 import okhttp3.OkHttpClient
+import sh.hnet.comfychair.util.DebugLogger
+import java.security.cert.CertificateException
 import java.security.cert.X509Certificate
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
+import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
 
 /**
@@ -16,120 +19,123 @@ enum class CertificateIssue {
 }
 
 /**
- * SelfSignedCertHelper - Helps handle SSL certificate issues
+ * SelfSignedCertHelper - Handles SSL certificate validation with system-first approach
  *
- * In production environments, SSL certificates are issued by trusted Certificate Authorities (CAs).
- * However, many local ComfyUI servers use:
- * 1. Self-signed certificates (not signed by any CA)
- * 2. Certificates from custom/private CAs (not in device's trusted CA store)
+ * Strategy:
+ * 1. Try the system default TrustManager first (validates Let's Encrypt, etc.)
+ * 2. If system validation fails, classify the issue (self-signed vs unknown CA)
+ * 3. Accept the certificate but record the issue type for UI feedback
  *
- * This helper allows the app to connect to such servers while
- * tracking what type of certificate issue was detected.
+ * This way:
+ * - Valid certs (Let's Encrypt, etc.) → NONE, no warning
+ * - Self-signed certs → SELF_SIGNED, user sees warning
+ * - Unknown CA certs → UNKNOWN_CA, user sees warning
  */
 object SelfSignedCertHelper {
+
+    private const val TAG = "SelfSignedCertHelper"
 
     // Track what type of certificate issue was detected
     var certificateIssue = CertificateIssue.NONE
         private set
 
     /**
-     * Create a custom TrustManager that accepts all certificates
-     * This is necessary for self-signed and unknown CA certificates
-     *
-     * SECURITY NOTE: This trusts ALL certificates, including invalid ones.
-     * Only use this for connections to known, trusted local servers.
+     * Get the system default X509TrustManager.
      */
-    private fun createTrustManager(): X509TrustManager {
+    private fun getSystemTrustManager(): X509TrustManager {
+        val factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        factory.init(null as java.security.KeyStore?)
+        return factory.trustManagers
+            .filterIsInstance<X509TrustManager>()
+            .first()
+    }
+
+    /**
+     * Create a TrustManager that tries system validation first,
+     * then falls back to accepting with classification.
+     */
+    private fun createSmartTrustManager(): X509TrustManager {
+        val systemTrustManager = try {
+            getSystemTrustManager()
+        } catch (e: Exception) {
+            DebugLogger.w(TAG, "Failed to get system TrustManager: ${e.message}")
+            null
+        }
+
         return object : X509TrustManager {
-            /**
-             * Check if client certificates are trusted
-             * For our use case, we accept all client certificates
-             */
             override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
                 // Accept all client certificates
             }
 
-            /**
-             * Check if server certificates are trusted
-             * This is where we detect certificate issues
-             *
-             * @param chain The certificate chain from the server
-             * @param authType The authentication type (e.g., "RSA", "ECDSA")
-             */
             override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
-                // If we receive a certificate chain, analyze it
-                if (chain != null && chain.isNotEmpty()) {
-                    val cert = chain[0] // Get the server's certificate
+                if (chain == null || chain.isEmpty()) return
 
-                    // Get issuer and subject Distinguished Names
-                    // Issuer: Who created/signed the certificate
-                    // Subject: Who the certificate is for
-                    val issuer = cert.issuerDN.name
-                    val subject = cert.subjectDN.name
-
-                    if (issuer == subject) {
-                        // Self-signed certificate: the certificate signed itself
-                        // Example: A ComfyUI server that generated its own certificate
-                        certificateIssue = CertificateIssue.SELF_SIGNED
-                    } else {
-                        // Certificate is signed by someone else (a CA)
-                        // But since we're in this custom trust manager, it means
-                        // the default validation failed - so it's an unknown CA
-                        // Example: A private CA that's not in Android's trusted CA store
-                        certificateIssue = CertificateIssue.UNKNOWN_CA
+                // Try system validation first
+                if (systemTrustManager != null) {
+                    try {
+                        systemTrustManager.checkServerTrusted(chain, authType)
+                        // System trusts it — valid cert, no issue
+                        certificateIssue = CertificateIssue.NONE
+                        DebugLogger.d(TAG, "Certificate validated by system trust store")
+                        return
+                    } catch (e: CertificateException) {
+                        // System doesn't trust it — classify the issue
+                        DebugLogger.d(TAG, "System validation failed: ${e.message}")
                     }
                 }
-                // Accept the certificate regardless of the issue
+
+                // System validation failed — classify and accept
+                val cert = chain[0]
+                val issuer = cert.issuerDN.name
+                val subject = cert.subjectDN.name
+
+                certificateIssue = if (issuer == subject) {
+                    DebugLogger.d(TAG, "Self-signed certificate detected")
+                    CertificateIssue.SELF_SIGNED
+                } else {
+                    DebugLogger.d(TAG, "Unknown CA certificate: issuer=$issuer")
+                    CertificateIssue.UNKNOWN_CA
+                }
+                // Accept the certificate regardless
             }
 
-            /**
-             * Return the list of accepted certificate issuers
-             * We accept all, so return empty array
-             */
             override fun getAcceptedIssuers(): Array<X509Certificate> {
-                return arrayOf()
+                // Return system accepted issuers so TLS handshake works properly
+                return systemTrustManager?.acceptedIssuers ?: arrayOf()
             }
         }
     }
 
     /**
-     * Configure an OkHttpClient.Builder to accept certificates with issues
-     * (self-signed certificates and unknown CA certificates)
-     *
-     * @param builder The OkHttpClient.Builder to configure
-     * @return The configured builder (for method chaining)
+     * Configure an OkHttpClient.Builder to handle certificate issues gracefully.
+     * Uses system trust store first, falls back to accept-all for self-signed/unknown CA.
      */
     fun configureToAcceptSelfSigned(builder: OkHttpClient.Builder): OkHttpClient.Builder {
         try {
-            // Reset the certificate issue before each connection attempt
             certificateIssue = CertificateIssue.NONE
 
-            // Create our custom trust manager
-            val trustManager = createTrustManager()
+            val trustManager = createSmartTrustManager()
             val trustManagers = arrayOf<TrustManager>(trustManager)
 
-            // Create an SSL context with our trust manager
             val sslContext = SSLContext.getInstance("TLS")
             sslContext.init(null, trustManagers, java.security.SecureRandom())
 
-            // Configure the builder to use our SSL context
             builder.sslSocketFactory(sslContext.socketFactory, trustManager)
 
-            // Also disable hostname verification
-            // Normally, the SSL certificate must match the hostname
-            // For local servers (e.g., 192.168.1.100), this often doesn't match
+            // Still need permissive hostname verification for IP-based connections
+            // (e.g., 192.168.1.100 won't match any cert CN/SAN)
             builder.hostnameVerifier { _, _ -> true }
 
         } catch (e: Exception) {
-            // If SSL configuration fails, the builder will use default SSL settings
+            DebugLogger.w(TAG, "SSL configuration failed: ${e.message}")
         }
 
         return builder
     }
 
     /**
-     * Reset the certificate issue detection
-     * Should be called before each new connection attempt
+     * Reset the certificate issue detection.
+     * Should be called before each new connection attempt.
      */
     fun reset() {
         certificateIssue = CertificateIssue.NONE

--- a/app/src/main/java/sh/hnet/comfychair/WebViewAuthActivity.kt
+++ b/app/src/main/java/sh/hnet/comfychair/WebViewAuthActivity.kt
@@ -1,0 +1,346 @@
+package sh.hnet.comfychair
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.ViewGroup
+import android.webkit.CookieManager
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.FrameLayout
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.viewinterop.AndroidView
+import sh.hnet.comfychair.ui.theme.ComfyChairTheme
+
+/**
+ * Activity that presents a WebView for browser-based authentication.
+ *
+ * Used with reverse proxies that have SSO/OAuth in front of ComfyUI (e.g., Authentik forward-auth).
+ * After the user authenticates, this activity captures all session cookies and returns them
+ * to the caller via the Activity result.
+ *
+ * Extras (input):
+ *   EXTRA_URL  — Full URL to load (e.g., "https://comfy.example.com")
+ *   EXTRA_HOST — ComfyUI hostname used to detect when auth is complete
+ *
+ * Result extras:
+ *   EXTRA_COOKIES             — Raw Cookie header string for the ComfyUI server
+ *   EXTRA_AUTH_DOMAIN         — Hostname of the SSO/auth domain (e.g. "auth.bun.cafe")
+ *   EXTRA_AUTH_DOMAIN_COOKIES — Raw Cookie header string for the auth domain
+ */
+class WebViewAuthActivity : ComponentActivity() {
+
+    companion object {
+        const val EXTRA_URL = "url"
+        const val EXTRA_HOST = "host"
+        const val EXTRA_COOKIES = "cookies"
+        const val EXTRA_AUTH_DOMAIN = "auth_domain"
+        const val EXTRA_AUTH_DOMAIN_COOKIES = "auth_domain_cookies"
+
+        /** Launch this activity and expect a result via ActivityResultLauncher. */
+        fun createIntent(context: Context, url: String, host: String): Intent {
+            return Intent(context, WebViewAuthActivity::class.java).apply {
+                putExtra(EXTRA_URL, url)
+                putExtra(EXTRA_HOST, host)
+            }
+        }
+
+        /**
+         * Collect all cookies from Android's CookieManager for a given URL and any
+         * auth-domain cookies that were set during the session, merging them into a
+         * single "Cookie: name=value; name2=value2" header string.
+         *
+         * We collect from the target URL and trust the system CookieManager to have
+         * accumulated cookies across all redirect domains visited in the WebView.
+         */
+        fun extractCookies(targetUrl: String): String {
+            val cookieManager = CookieManager.getInstance()
+            // CookieManager.getCookie returns the cookies applicable to the given URL
+            // (respects domain/path scoping). This is exactly what OkHttp will need
+            // to pass when talking to the ComfyUI server.
+            return cookieManager.getCookie(targetUrl)?.trim() ?: ""
+        }
+
+        /**
+         * Find the first non-ComfyUI domain visited during auth and return its cookies.
+         * This is the SSO/auth domain whose session cookie enables silent token refresh.
+         *
+         * @param visitedDomains All hostnames visited during the WebView session
+         * @param comfyHost The ComfyUI hostname to exclude
+         * @return Pair of (authDomain, authDomainCookies), both empty if not found
+         */
+        fun extractAuthDomainCookies(visitedDomains: Collection<String>, comfyHost: String): Pair<String, String> {
+            val cookieManager = CookieManager.getInstance()
+            for (domain in visitedDomains) {
+                if (domain.equals(comfyHost, ignoreCase = true)) continue
+                // Try https first (most auth servers use HTTPS), then http
+                val cookies = (cookieManager.getCookie("https://$domain")?.trim()
+                    ?: cookieManager.getCookie("http://$domain")?.trim())
+                    ?.takeIf { it.isNotEmpty() }
+                if (!cookies.isNullOrEmpty()) {
+                    return Pair(domain, cookies)
+                }
+            }
+            return Pair("", "")
+        }
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val url = intent.getStringExtra(EXTRA_URL) ?: run {
+            setResult(Activity.RESULT_CANCELED)
+            finish()
+            return
+        }
+        val host = intent.getStringExtra(EXTRA_HOST) ?: ""
+
+        // Clear cookies for the target domain so the user hits the auth flow fresh.
+        // We only clear the target domain's cookies — not removeAllCookies() which
+        // would nuke cookies for every site the system WebView has visited.
+        CookieManager.getInstance().apply {
+            setAcceptCookie(true)
+            clearCookiesForUrl(url)
+            flush()
+        }
+
+        setContent {
+            ComfyChairTheme {
+                WebViewAuthScreen(
+                    url = url,
+                    host = host,
+                    onDone = { cookies, authDomain, authDomainCookies ->
+                        val result = Intent().apply {
+                            putExtra(EXTRA_COOKIES, cookies)
+                            putExtra(EXTRA_AUTH_DOMAIN, authDomain)
+                            putExtra(EXTRA_AUTH_DOMAIN_COOKIES, authDomainCookies)
+                        }
+                        setResult(Activity.RESULT_OK, result)
+                        finish()
+                    },
+                    onCancel = {
+                        setResult(Activity.RESULT_CANCELED)
+                        finish()
+                    }
+                )
+            }
+        }
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun WebViewAuthScreen(
+    url: String,
+    host: String,
+    onDone: (cookies: String, authDomain: String, authDomainCookies: String) -> Unit,
+    onCancel: () -> Unit
+) {
+    var isLoading by remember { mutableStateOf(true) }
+    var currentUrl by remember { mutableStateOf(url) }
+    // Whether we're back on the ComfyUI server (auth chain likely complete)
+    var authAppearsComplete by remember { mutableStateOf(false) }
+    var webViewRef: WebView? by remember { mutableStateOf(null) }
+
+    // Track all non-ComfyUI hostnames visited during the auth redirect chain.
+    // The first one is typically the SSO/auth domain whose session cookie enables
+    // silent OkHttp token refresh without needing to show the WebView again.
+    val visitedAuthDomains = remember { LinkedHashSet<String>() }
+
+    fun collectAndReturn() {
+        val cookies = WebViewAuthActivity.extractCookies(url)
+        val (authDomain, authDomainCookies) = WebViewAuthActivity.extractAuthDomainCookies(visitedAuthDomains, host)
+        onDone(cookies, authDomain, authDomainCookies)
+    }
+
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            TopAppBar(
+                modifier = Modifier.statusBarsPadding(),
+                title = {
+                    Column {
+                        Text(
+                            text = stringResource(R.string.title_browser_auth),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        if (currentUrl.isNotEmpty()) {
+                            Text(
+                                text = currentUrl,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1
+                            )
+                        }
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = onCancel) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = stringResource(R.string.button_cancel)
+                        )
+                    }
+                },
+                actions = {
+                    // Done button - enabled when we detect auth is complete OR always available
+                    // so the user can manually signal "I'm done"
+                    IconButton(onClick = { collectAndReturn() }) {
+                        Icon(
+                            imageVector = Icons.Default.Check,
+                            contentDescription = stringResource(R.string.button_browser_auth_done),
+                            tint = if (authAppearsComplete) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurface
+                            }
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = if (authAppearsComplete) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surface
+                    }
+                )
+            )
+
+            if (isLoading) {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
+
+            Box(modifier = Modifier.fillMaxSize()) {
+                AndroidView(
+                    factory = { context ->
+                        WebView(context).apply {
+                            layoutParams = FrameLayout.LayoutParams(
+                                ViewGroup.LayoutParams.MATCH_PARENT,
+                                ViewGroup.LayoutParams.MATCH_PARENT
+                            )
+                            settings.apply {
+                                javaScriptEnabled = true
+                                domStorageEnabled = true
+                                // Allow mixed content for servers that may redirect between
+                                // http/https during the auth flow
+                                @SuppressLint("SetJavaScriptEnabled")
+                                setSupportMultipleWindows(false)
+                                userAgentString = "ComfyChair/1.0 (Android)"
+                            }
+
+                            CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+
+                            webViewClient = object : WebViewClient() {
+                                override fun onPageStarted(
+                                    view: WebView?,
+                                    pageUrl: String?,
+                                    favicon: android.graphics.Bitmap?
+                                ) {
+                                    isLoading = true
+                                    currentUrl = pageUrl ?: ""
+                                    // Check if we're back on the ComfyUI host
+                                    authAppearsComplete = isOnTargetHost(pageUrl, host)
+                                    // Record any non-ComfyUI domain we land on — this is
+                                    // the auth/SSO domain whose cookies enable silent refresh.
+                                    val pageHost = try {
+                                        Uri.parse(pageUrl ?: "").host ?: ""
+                                    } catch (e: Exception) { "" }
+                                    if (pageHost.isNotEmpty() && !pageHost.equals(host, ignoreCase = true)) {
+                                        visitedAuthDomains.add(pageHost)
+                                    }
+                                }
+
+                                override fun onPageFinished(view: WebView?, pageUrl: String?) {
+                                    isLoading = false
+                                    currentUrl = pageUrl ?: ""
+                                    authAppearsComplete = isOnTargetHost(pageUrl, host)
+                                    // Flush cookies to disk so getCookie() is up to date
+                                    CookieManager.getInstance().flush()
+                                    // Auto-finish if we're back on the ComfyUI host AND cookies exist
+                                    if (authAppearsComplete) {
+                                        val cookies = WebViewAuthActivity.extractCookies(url)
+                                        if (cookies.isNotEmpty()) {
+                                            collectAndReturn()
+                                        }
+                                        // If no cookies yet, don't auto-finish — user can
+                                        // manually tap Done or the redirect chain will continue
+                                    }
+                                }
+
+                                override fun shouldOverrideUrlLoading(
+                                    view: WebView?,
+                                    request: WebResourceRequest?
+                                ): Boolean {
+                                    // Let the WebView handle all redirects internally
+                                    return false
+                                }
+                            }
+
+                            loadUrl(url)
+                            webViewRef = this
+                        }
+                    },
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Clear cookies for a specific URL by setting each cookie's value to empty with
+ * an expired date. CookieManager has no per-URL delete API, so this is the
+ * standard workaround.
+ */
+private fun CookieManager.clearCookiesForUrl(url: String) {
+    val existing = getCookie(url) ?: return
+    existing.split(";").forEach { cookie ->
+        val name = cookie.trim().split("=").firstOrNull()?.trim() ?: return@forEach
+        setCookie(url, "$name=; Expires=Thu, 01 Jan 1970 00:00:00 GMT")
+    }
+}
+
+/**
+ * Returns true if [pageUrl] is on the same host as [targetHost].
+ * Used to detect when the auth redirect chain has returned us to the ComfyUI server.
+ */
+private fun isOnTargetHost(pageUrl: String?, targetHost: String): Boolean {
+    if (pageUrl.isNullOrEmpty() || targetHost.isEmpty()) return false
+    return try {
+        val uri = Uri.parse(pageUrl)
+        uri.host?.equals(targetHost, ignoreCase = true) == true
+    } catch (e: Exception) {
+        false
+    }
+}

--- a/app/src/main/java/sh/hnet/comfychair/connection/ConnectionManager.kt
+++ b/app/src/main/java/sh/hnet/comfychair/connection/ConnectionManager.kt
@@ -2,6 +2,7 @@ package sh.hnet.comfychair.connection
 
 import android.content.Context
 import android.graphics.BitmapFactory
+import android.net.Uri
 import android.widget.Toast
 import sh.hnet.comfychair.R
 import kotlinx.coroutines.CoroutineScope
@@ -19,13 +20,17 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.ByteString
 import org.json.JSONObject
 import sh.hnet.comfychair.ComfyUIClient
+import sh.hnet.comfychair.SelfSignedCertHelper
 import sh.hnet.comfychair.WorkflowManager
 import sh.hnet.comfychair.model.AuthCredentials
 import sh.hnet.comfychair.cache.MediaCache
@@ -33,12 +38,15 @@ import sh.hnet.comfychair.cache.MediaStateHolder
 import sh.hnet.comfychair.queue.JobRegistry
 import sh.hnet.comfychair.repository.GalleryRepository
 import sh.hnet.comfychair.storage.AppSettings
+import sh.hnet.comfychair.storage.CredentialStorage
 import sh.hnet.comfychair.storage.ObjectInfoCache
 import sh.hnet.comfychair.util.DebugLogger
 import sh.hnet.comfychair.util.Obfuscator
 import sh.hnet.comfychair.workflow.NodeTypeRegistry
 import sh.hnet.comfychair.workflow.TemplateKeyRegistry
+import java.io.IOException
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 
 /**
  * Connection state representing whether the app is connected to a ComfyUI server.
@@ -111,6 +119,23 @@ object ConnectionManager {
     // Reconnection in progress (for "Reconnecting..." dialog button state)
     private val _isReconnecting = MutableStateFlow(false)
     val isReconnecting: StateFlow<Boolean> = _isReconnecting.asStateFlow()
+
+    // Browser auth session expired — triggers re-auth flow in UI
+    private val _sessionExpired = MutableStateFlow(false)
+    val sessionExpired: StateFlow<Boolean> = _sessionExpired.asStateFlow()
+
+    /**
+     * Set to true when the silent OkHttp cookie refresh fails (e.g. auth session also expired).
+     * The UI observes this to decide whether to show the manual re-auth dialog.
+     */
+    private val _silentRefreshFailed = MutableStateFlow(false)
+    val silentRefreshFailed: StateFlow<Boolean> = _silentRefreshFailed.asStateFlow()
+
+    /** Reset session expired and silent-refresh-failed flags after re-auth completes. */
+    fun clearSessionExpired() {
+        _sessionExpired.value = false
+        _silentRefreshFailed.value = false
+    }
 
     private var _client: ComfyUIClient? = null
     private var _clientId: String? = null
@@ -256,6 +281,12 @@ object ConnectionManager {
         _client = ComfyUIClient(context.applicationContext, hostname, port, credentials).apply {
             setWorkingProtocol(protocol)
             setClientId(_clientId!!)
+            // Wire session expiry detection for cookie-based auth.
+            // Attempt silent OkHttp refresh first; show UI dialog only on failure.
+            authInterceptor.onSessionExpired = {
+                DebugLogger.w(TAG, "Browser auth session expired — attempting silent OkHttp refresh")
+                attemptSilentCookieRefresh()
+            }
         }
 
         _connectionState.value = ConnectionState.Connected(
@@ -552,6 +583,176 @@ object ConnectionManager {
                     failureType = failureType
                 )
                 // Dialog will appear via existing GenerationViewModel observation
+            }
+        }
+    }
+
+    /**
+     * Attempt to silently refresh the ComfyUI outpost cookie via OkHttp — no UI required.
+     *
+     * Flow:
+     *   1. GET server URL (no redirect follow) → 302 to auth domain
+     *   2. GET auth domain URL with stored auth session cookie → 302 back to ComfyUI
+     *      (auth domain response carries Set-Cookie for the fresh outpost cookie)
+     *   3. Collect all Set-Cookie headers across the redirect chain and merge with existing cookies
+     *   4. On success: update credentials + reconnect silently
+     *   5. On failure: set sessionExpired + silentRefreshFailed so UI shows the dialog
+     */
+    private fun attemptSilentCookieRefresh() {
+        val creds = _client?.getCredentials() as? AuthCredentials.Cookie
+        val authDomain = creds?.authDomain ?: ""
+        val authDomainCookies = creds?.authDomainCookies ?: ""
+
+        if (creds == null || authDomain.isEmpty() || authDomainCookies.isEmpty()) {
+            DebugLogger.w(TAG, "Silent cookie refresh: no auth domain stored, falling back to UI dialog")
+            _silentRefreshFailed.value = true
+            _sessionExpired.value = true
+            return
+        }
+
+        val connState = connectionState.value as? ConnectionState.Connected ?: run {
+            DebugLogger.w(TAG, "Silent cookie refresh: not connected, skipping")
+            _silentRefreshFailed.value = true
+            _sessionExpired.value = true
+            return
+        }
+
+        scope.launch(Dispatchers.IO) {
+            try {
+                // Dedicated OkHttp client for the refresh — no auth interceptor (avoids loops),
+                // no automatic redirect following (we inject cookies per-domain manually).
+                val refreshClient: OkHttpClient = SelfSignedCertHelper.configureToAcceptSelfSigned(
+                    OkHttpClient.Builder()
+                        .connectTimeout(15, TimeUnit.SECONDS)
+                        .readTimeout(15, TimeUnit.SECONDS)
+                        .writeTimeout(15, TimeUnit.SECONDS)
+                        .followRedirects(false)
+                        .followSslRedirects(false)
+                ).build()
+
+                val comfyHost = connState.hostname
+                val serverUrl = "${connState.protocol}://${connState.hostname}:${connState.port}/system_stats"
+
+                // Seed the per-domain cookie map from existing (possibly expired) ComfyUI cookies.
+                // We'll overwrite individual entries as Set-Cookie headers arrive.
+                val cookieMap = LinkedHashMap<String, String>()
+                creds.cookies.split(";").forEach { part ->
+                    val kv = part.trim().split("=", limit = 2)
+                    if (kv.size == 2) cookieMap[kv[0].trim()] = kv[1].trim()
+                }
+
+                var currentUrl = serverUrl
+                var success = false
+                val maxRedirects = 10
+                var redirectCount = 0
+
+                while (redirectCount < maxRedirects) {
+                    val currentHost = try {
+                        Uri.parse(currentUrl).host ?: break
+                    } catch (e: Exception) { break }
+
+                    val requestBuilder = Request.Builder().url(currentUrl).get()
+
+                    // Inject cookies appropriate to the host we're contacting
+                    when {
+                        currentHost.equals(comfyHost, ignoreCase = true) -> {
+                            val cookieStr = cookieMap.entries.joinToString("; ") { "${it.key}=${it.value}" }
+                            if (cookieStr.isNotEmpty()) requestBuilder.header("Cookie", cookieStr)
+                        }
+                        currentHost.equals(authDomain, ignoreCase = true) -> {
+                            requestBuilder.header("Cookie", authDomainCookies)
+                        }
+                        // Unknown host — no cookies injected
+                    }
+
+                    val response: Response = try {
+                        refreshClient.newCall(requestBuilder.build()).execute()
+                    } catch (e: IOException) {
+                        DebugLogger.w(TAG, "Silent cookie refresh: network error at $currentHost: ${e.message}")
+                        break
+                    }
+
+                    // Collect all Set-Cookie headers from this response.
+                    // Parse only the name=value portion (ignore Path/Domain/Expires attributes).
+                    response.headers("Set-Cookie").forEach { header ->
+                        val nameValue = header.split(";")[0].trim()
+                        val kv = nameValue.split("=", limit = 2)
+                        if (kv.size == 2) cookieMap[kv[0].trim()] = kv[1].trim()
+                    }
+
+                    if (response.isRedirect) {
+                        val location = response.header("Location")
+                        if (location == null) {
+                            response.close()
+                            break
+                        }
+
+                        // Resolve relative Location URLs
+                        val nextUrl = when {
+                            location.startsWith("http://") || location.startsWith("https://") -> location
+                            location.startsWith("/") -> "${connState.protocol}://$currentHost$location"
+                            else -> location
+                        }
+
+                        // If we're being redirected back to the ComfyUI host after having
+                        // visited the auth domain, the outpost cookie should be in cookieMap now.
+                        val nextHost = try { Uri.parse(nextUrl).host ?: "" } catch (e: Exception) { "" }
+                        if (nextHost.equals(comfyHost, ignoreCase = true) && redirectCount > 0) {
+                            // Auth domain redirected us back — success, no need to follow further.
+                            DebugLogger.i(TAG, "Silent cookie refresh: auth domain redirected back to ComfyUI")
+                            success = true
+                            response.close()
+                            break
+                        }
+
+                        response.close()
+                        currentUrl = nextUrl
+                        redirectCount++
+                    } else if (response.isSuccessful) {
+                        // Reached ComfyUI directly (maybe cookies were still valid or no redirect needed)
+                        DebugLogger.i(TAG, "Silent cookie refresh: reached ComfyUI successfully")
+                        success = true
+                        response.close()
+                        break
+                    } else {
+                        DebugLogger.w(TAG, "Silent cookie refresh: unexpected status ${response.code} at $currentHost")
+                        response.close()
+                        break
+                    }
+                }
+
+                if (success && cookieMap.isNotEmpty()) {
+                    val newCookieString = cookieMap.entries.joinToString("; ") { "${it.key}=${it.value}" }
+                    val newCreds = AuthCredentials.Cookie(
+                        cookies = newCookieString,
+                        authDomain = authDomain,
+                        authDomainCookies = authDomainCookies
+                    )
+
+                    // Update in-memory credentials (resets sessionExpiredFired in AuthInterceptor)
+                    _client?.setCredentials(newCreds)
+
+                    // Persist to encrypted storage
+                    val ctx = _applicationContext
+                    val serverId = connState.serverId
+                    if (ctx != null) {
+                        CredentialStorage(ctx).saveCredentials(serverId, newCreds)
+                    }
+
+                    // Clear expiry flags and reconnect silently
+                    _silentRefreshFailed.value = false
+                    _sessionExpired.value = false
+                    DebugLogger.i(TAG, "Silent cookie refresh: success — reconnecting")
+                    withContext(Dispatchers.Main) { attemptSilentReconnect() }
+                } else {
+                    DebugLogger.w(TAG, "Silent cookie refresh: failed after $redirectCount redirects — showing UI dialog")
+                    _silentRefreshFailed.value = true
+                    _sessionExpired.value = true
+                }
+            } catch (e: Exception) {
+                DebugLogger.e(TAG, "Silent cookie refresh: unexpected exception: ${e.message}")
+                _silentRefreshFailed.value = true
+                _sessionExpired.value = true
             }
         }
     }
@@ -907,7 +1108,8 @@ object ConnectionManager {
                 _modelCache.value = models.copy(isLoaded = true, isLoading = false)
                 DebugLogger.i(TAG, "Server data loaded: ${models.checkpoints.size} checkpoints, " +
                         "${models.unets.size} unets, ${models.vaes.size} vaes, " +
-                        "${models.clips.size} clips, ${models.loras.size} loras")
+                        "${models.clips.size} clips, ${models.loras.size} loras, " +
+                        "${models.samplers.size} samplers, ${models.schedulers.size} schedulers")
             } else {
                 DebugLogger.w(TAG, "Failed to fetch server data")
                 _modelCache.value = _modelCache.value.copy(
@@ -1030,7 +1232,24 @@ object ConnectionManager {
             latentUpscaleModels = nodeTypeRegistry.getOptionsForNodeInput(
                 "LatentUpscaleModelLoader",
                 TemplateKeyRegistry.getJsonKeyForPlaceholder("latent_upscale_model")
-            )
+            ),
+            // Samplers/schedulers from KSampler node — captures custom-node additions
+            samplers = nodeTypeRegistry.getOptionsForNodeInput(
+                "KSampler",
+                TemplateKeyRegistry.getJsonKeyForPlaceholder("sampler_name")
+            ).ifEmpty {
+                nodeTypeRegistry.getOptionsForField(
+                    TemplateKeyRegistry.getJsonKeyForPlaceholder("sampler_name")
+                )
+            },
+            schedulers = nodeTypeRegistry.getOptionsForNodeInput(
+                "KSampler",
+                TemplateKeyRegistry.getJsonKeyForPlaceholder("scheduler")
+            ).ifEmpty {
+                nodeTypeRegistry.getOptionsForField(
+                    TemplateKeyRegistry.getJsonKeyForPlaceholder("scheduler")
+                )
+            }
         )
     }
 }

--- a/app/src/main/java/sh/hnet/comfychair/model/AuthCredentials.kt
+++ b/app/src/main/java/sh/hnet/comfychair/model/AuthCredentials.kt
@@ -20,4 +20,20 @@ sealed class AuthCredentials {
     data class Bearer(
         val token: String
     ) : AuthCredentials()
+
+    /** Browser-captured session cookies (e.g., from Authentik SSO) */
+    data class Cookie(
+        /** Raw Cookie header string for the ComfyUI server (e.g. outpost cookie). */
+        val cookies: String,
+        /**
+         * Hostname of the SSO/auth domain (e.g. "auth.bun.cafe").
+         * Empty if not yet captured or not applicable.
+         */
+        val authDomain: String = "",
+        /**
+         * Raw Cookie header string for the auth domain (e.g. Authentik session cookie).
+         * Used by the OkHttp silent refresh flow to re-authenticate without UI.
+         */
+        val authDomainCookies: String = ""
+    ) : AuthCredentials()
 }

--- a/app/src/main/java/sh/hnet/comfychair/model/AuthType.kt
+++ b/app/src/main/java/sh/hnet/comfychair/model/AuthType.kt
@@ -9,5 +9,7 @@ enum class AuthType {
     /** HTTP Basic authentication (username + password) */
     BASIC,
     /** API key or bearer token authentication */
-    BEARER
+    BEARER,
+    /** Browser-based authentication (e.g., OAuth/SSO via Authentik forward-auth) */
+    BROWSER
 }

--- a/app/src/main/java/sh/hnet/comfychair/model/Server.kt
+++ b/app/src/main/java/sh/hnet/comfychair/model/Server.kt
@@ -13,7 +13,8 @@ data class Server(
     val name: String,
     val hostname: String,
     val port: Int,
-    val authType: AuthType = AuthType.NONE
+    val authType: AuthType = AuthType.NONE,
+    val trustCert: Boolean = false // User accepted untrusted cert for this server
 ) {
     companion object {
         /**
@@ -44,7 +45,9 @@ data class Server(
                 AuthType.NONE
             }
 
-            return Server(id, name, hostname, port, authType)
+            val trustCert = json.optBoolean("trustCert", false)
+
+            return Server(id, name, hostname, port, authType, trustCert)
         }
     }
 
@@ -58,6 +61,7 @@ data class Server(
             put("hostname", hostname)
             put("port", port)
             put("authType", authType.name)
+            put("trustCert", trustCert)
         }
     }
 

--- a/app/src/main/java/sh/hnet/comfychair/storage/CredentialStorage.kt
+++ b/app/src/main/java/sh/hnet/comfychair/storage/CredentialStorage.kt
@@ -20,6 +20,9 @@ class CredentialStorage(context: Context) {
         private const val KEY_USERNAME_PREFIX = "username_"
         private const val KEY_PASSWORD_PREFIX = "password_"
         private const val KEY_TOKEN_PREFIX = "token_"
+        private const val KEY_COOKIES_PREFIX = "cookies_"
+        private const val KEY_AUTH_DOMAIN_PREFIX = "auth_domain_"
+        private const val KEY_AUTH_DOMAIN_COOKIES_PREFIX = "auth_domain_cookies_"
     }
 
     private val prefs: SharedPreferences by lazy {
@@ -53,6 +56,8 @@ class CredentialStorage(context: Context) {
             remove("$KEY_USERNAME_PREFIX$serverId")
             remove("$KEY_PASSWORD_PREFIX$serverId")
             remove("$KEY_TOKEN_PREFIX$serverId")
+            remove("$KEY_AUTH_DOMAIN_PREFIX$serverId")
+            remove("$KEY_AUTH_DOMAIN_COOKIES_PREFIX$serverId")
 
             when (credentials) {
                 is AuthCredentials.None -> { /* Nothing to store */ }
@@ -62,6 +67,13 @@ class CredentialStorage(context: Context) {
                 }
                 is AuthCredentials.Bearer -> {
                     putString("$KEY_TOKEN_PREFIX$serverId", credentials.token)
+                }
+                is AuthCredentials.Cookie -> {
+                    putString("$KEY_COOKIES_PREFIX$serverId", credentials.cookies)
+                    if (credentials.authDomain.isNotEmpty()) {
+                        putString("$KEY_AUTH_DOMAIN_PREFIX$serverId", credentials.authDomain)
+                        putString("$KEY_AUTH_DOMAIN_COOKIES_PREFIX$serverId", credentials.authDomainCookies)
+                    }
                 }
             }
             apply()
@@ -95,6 +107,16 @@ class CredentialStorage(context: Context) {
                     AuthCredentials.None
                 }
             }
+            AuthType.BROWSER -> {
+                val cookies = prefs.getString("$KEY_COOKIES_PREFIX$serverId", null)
+                if (cookies != null) {
+                    val authDomain = prefs.getString("$KEY_AUTH_DOMAIN_PREFIX$serverId", null) ?: ""
+                    val authDomainCookies = prefs.getString("$KEY_AUTH_DOMAIN_COOKIES_PREFIX$serverId", null) ?: ""
+                    AuthCredentials.Cookie(cookies, authDomain, authDomainCookies)
+                } else {
+                    AuthCredentials.None
+                }
+            }
         }
     }
 
@@ -107,6 +129,9 @@ class CredentialStorage(context: Context) {
             remove("$KEY_USERNAME_PREFIX$serverId")
             remove("$KEY_PASSWORD_PREFIX$serverId")
             remove("$KEY_TOKEN_PREFIX$serverId")
+            remove("$KEY_COOKIES_PREFIX$serverId")
+            remove("$KEY_AUTH_DOMAIN_PREFIX$serverId")
+            remove("$KEY_AUTH_DOMAIN_COOKIES_PREFIX$serverId")
             apply()
         }
         DebugLogger.d(TAG, "Deleted credentials for server $serverId")
@@ -124,6 +149,9 @@ class CredentialStorage(context: Context) {
             }
             AuthType.BEARER -> {
                 prefs.getString("$KEY_TOKEN_PREFIX$serverId", null) != null
+            }
+            AuthType.BROWSER -> {
+                prefs.getString("$KEY_COOKIES_PREFIX$serverId", null) != null
             }
         }
     }

--- a/app/src/main/java/sh/hnet/comfychair/ui/components/ServerDialog.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/components/ServerDialog.kt
@@ -107,6 +107,16 @@ fun ServerDialog(
             (existingCredentials as? AuthCredentials.Cookie)?.cookies ?: ""
         )
     }
+    var browserAuthDomain by remember {
+        mutableStateOf(
+            (existingCredentials as? AuthCredentials.Cookie)?.authDomain ?: ""
+        )
+    }
+    var browserAuthDomainCookies by remember {
+        mutableStateOf(
+            (existingCredentials as? AuthCredentials.Cookie)?.authDomainCookies ?: ""
+        )
+    }
     var passwordVisible by remember { mutableStateOf(false) }
     var tokenVisible by remember { mutableStateOf(false) }
 
@@ -126,6 +136,8 @@ fun ServerDialog(
         if (result.resultCode == Activity.RESULT_OK) {
             val cookies = result.data?.getStringExtra(WebViewAuthActivity.EXTRA_COOKIES) ?: ""
             browserCookies = cookies
+            browserAuthDomain = result.data?.getStringExtra(WebViewAuthActivity.EXTRA_AUTH_DOMAIN) ?: ""
+            browserAuthDomainCookies = result.data?.getStringExtra(WebViewAuthActivity.EXTRA_AUTH_DOMAIN_COOKIES) ?: ""
         }
     }
 
@@ -229,7 +241,11 @@ fun ServerDialog(
             AuthType.BASIC -> AuthCredentials.Basic(username.trim(), password)
             AuthType.BEARER -> AuthCredentials.Bearer(token.trim())
             AuthType.BROWSER -> if (browserCookies.isNotEmpty()) {
-                AuthCredentials.Cookie(browserCookies)
+                AuthCredentials.Cookie(
+                    cookies = browserCookies,
+                    authDomain = browserAuthDomain,
+                    authDomainCookies = browserAuthDomainCookies
+                )
             } else {
                 AuthCredentials.None
             }

--- a/app/src/main/java/sh/hnet/comfychair/ui/components/ServerDialog.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/components/ServerDialog.kt
@@ -12,14 +12,21 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.Password
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
+import sh.hnet.comfychair.WebViewAuthActivity
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
@@ -29,6 +36,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleButton
+import android.app.Activity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -73,6 +81,8 @@ fun ServerDialog(
     var name by remember { mutableStateOf(server?.name ?: "") }
     var hostname by remember { mutableStateOf(server?.hostname ?: "") }
     var port by remember { mutableStateOf(server?.port?.toString() ?: "8188") }
+    val isCustomPort = server?.port != null && server.port != 443 && server.port != 80
+    var showPortField by remember { mutableStateOf(isCustomPort || server?.authType != AuthType.BROWSER) }
 
     // Authentication state
     var authType by remember { mutableStateOf(server?.authType ?: AuthType.NONE) }
@@ -91,6 +101,12 @@ fun ServerDialog(
             (existingCredentials as? AuthCredentials.Bearer)?.token ?: ""
         )
     }
+    // Browser auth: captures cookies after WebView login
+    var browserCookies by remember {
+        mutableStateOf(
+            (existingCredentials as? AuthCredentials.Cookie)?.cookies ?: ""
+        )
+    }
     var passwordVisible by remember { mutableStateOf(false) }
     var tokenVisible by remember { mutableStateOf(false) }
 
@@ -101,6 +117,17 @@ fun ServerDialog(
     var usernameError by remember { mutableStateOf<String?>(null) }
     var passwordError by remember { mutableStateOf<String?>(null) }
     var tokenError by remember { mutableStateOf<String?>(null) }
+
+    // Browser auth WebView launcher
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val webViewLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val cookies = result.data?.getStringExtra(WebViewAuthActivity.EXTRA_COOKIES) ?: ""
+            browserCookies = cookies
+        }
+    }
 
     // Focus requester for name field
     val nameFocusRequester = remember { FocusRequester() }
@@ -155,15 +182,18 @@ fun ServerDialog(
             isValid = false
         }
 
-        // Validate port
-        if (trimmedPort.isEmpty()) {
-            portError = errorRequired
-            isValid = false
-        } else {
-            val portNum = trimmedPort.toIntOrNull()
-            if (portNum == null || portNum !in 1..65535) {
-                portError = errorInvalidPort
+        // Validate port (skip if Browser auth with port hidden)
+        val portHidden = authType == AuthType.BROWSER && !showPortField
+        if (!portHidden) {
+            if (trimmedPort.isEmpty()) {
+                portError = errorRequired
                 isValid = false
+            } else {
+                val portNum = trimmedPort.toIntOrNull()
+                if (portNum == null || portNum !in 1..65535) {
+                    portError = errorInvalidPort
+                    isValid = false
+                }
             }
         }
 
@@ -186,6 +216,7 @@ fun ServerDialog(
                 }
             }
             AuthType.NONE -> { /* No validation needed */ }
+            AuthType.BROWSER -> { /* Cookies are optional — can be fetched on first connect */ }
         }
 
         return isValid
@@ -197,6 +228,11 @@ fun ServerDialog(
             AuthType.NONE -> AuthCredentials.None
             AuthType.BASIC -> AuthCredentials.Basic(username.trim(), password)
             AuthType.BEARER -> AuthCredentials.Bearer(token.trim())
+            AuthType.BROWSER -> if (browserCookies.isNotEmpty()) {
+                AuthCredentials.Cookie(browserCookies)
+            } else {
+                AuthCredentials.None
+            }
         }
     }
 
@@ -262,32 +298,48 @@ fun ServerDialog(
                     modifier = Modifier.fillMaxWidth()
                 )
 
-                // Port
-                OutlinedTextField(
-                    value = port,
-                    onValueChange = { newValue ->
-                        port = newValue
-                        // Live validation
-                        val trimmed = newValue.trim()
-                        portError = when {
-                            trimmed.isEmpty() -> null
-                            else -> {
-                                val portNum = trimmed.toIntOrNull()
-                                if (portNum == null || portNum !in 1..65535) {
-                                    errorInvalidPort
-                                } else {
-                                    null
+                // Port — hidden for Browser auth by default (DNS handles it), toggle to show
+                val hidePort = authType == AuthType.BROWSER && !showPortField
+                if (hidePort) {
+                    Button(
+                        onClick = { showPortField = true },
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.textButtonColors()
+                    ) {
+                        Icon(
+                            Icons.Default.Settings,
+                            contentDescription = null,
+                            modifier = Modifier.padding(end = 4.dp)
+                        )
+                        Text(stringResource(R.string.button_custom_port))
+                    }
+                } else {
+                    OutlinedTextField(
+                        value = port,
+                        onValueChange = { newValue ->
+                            port = newValue
+                            // Live validation
+                            val trimmed = newValue.trim()
+                            portError = when {
+                                trimmed.isEmpty() -> null
+                                else -> {
+                                    val portNum = trimmed.toIntOrNull()
+                                    if (portNum == null || portNum !in 1..65535) {
+                                        errorInvalidPort
+                                    } else {
+                                        null
+                                    }
                                 }
                             }
-                        }
-                    },
-                    label = { Text(stringResource(R.string.hint_port)) },
-                    isError = portError != null,
-                    supportingText = portError?.let { { Text(it) } },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    modifier = Modifier.fillMaxWidth()
-                )
+                        },
+                        label = { Text(stringResource(R.string.hint_port)) },
+                        isError = portError != null,
+                        supportingText = portError?.let { { Text(it) } },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
 
                 Spacer(modifier = Modifier.height(8.dp))
 
@@ -308,6 +360,7 @@ fun ServerDialog(
                         onCheckedChange = { isChecked ->
                             if (isChecked) {
                                 authType = AuthType.NONE
+                                showPortField = true
                                 usernameError = null
                                 passwordError = null
                                 tokenError = null
@@ -326,6 +379,7 @@ fun ServerDialog(
                         onCheckedChange = { isChecked ->
                             if (isChecked) {
                                 authType = AuthType.BASIC
+                                showPortField = true
                                 tokenError = null
                             }
                         },
@@ -342,16 +396,36 @@ fun ServerDialog(
                         onCheckedChange = { isChecked ->
                             if (isChecked) {
                                 authType = AuthType.BEARER
+                                showPortField = true
                                 usernameError = null
                                 passwordError = null
+                            }
+                        },
+                        modifier = Modifier.weight(1f),
+                        shapes = ButtonGroupDefaults.connectedMiddleButtonShapes()
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Key,
+                            contentDescription = stringResource(R.string.option_auth_type_bearer)
+                        )
+                    }
+                    ToggleButton(
+                        checked = authType == AuthType.BROWSER,
+                        onCheckedChange = { isChecked ->
+                            if (isChecked) {
+                                authType = AuthType.BROWSER
+                                showPortField = false
+                                usernameError = null
+                                passwordError = null
+                                tokenError = null
                             }
                         },
                         modifier = Modifier.weight(1f),
                         shapes = ButtonGroupDefaults.connectedTrailingButtonShapes()
                     ) {
                         Icon(
-                            imageVector = Icons.Default.Key,
-                            contentDescription = stringResource(R.string.option_auth_type_bearer)
+                            imageVector = Icons.Default.Language,
+                            contentDescription = stringResource(R.string.option_auth_type_browser)
                         )
                     }
                 }
@@ -407,6 +481,70 @@ fun ServerDialog(
                     }
                 }
 
+                // Browser auth section
+                AnimatedVisibility(visible = authType == AuthType.BROWSER) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.label_auth_browser_hint),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            OutlinedButton(
+                                onClick = {
+                                    val trimmedHostname = hostname.trim()
+                                    val portNum = if (authType == AuthType.BROWSER && !showPortField) {
+                                        443
+                                    } else {
+                                        port.trim().toIntOrNull() ?: 8188
+                                    }
+                                    if (trimmedHostname.isNotEmpty()) {
+                                        val serverUrl = when (portNum) {
+                                            443 -> "https://$trimmedHostname"
+                                            80 -> "http://$trimmedHostname"
+                                            else -> "http://$trimmedHostname:$portNum"
+                                        }
+                                        val intent = WebViewAuthActivity.createIntent(
+                                            context, serverUrl, trimmedHostname
+                                        )
+                                        webViewLauncher.launch(intent)
+                                    }
+                                },
+                                modifier = Modifier.weight(1f),
+                                enabled = hostname.trim().isNotEmpty()
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Language,
+                                    contentDescription = null,
+                                    modifier = Modifier.padding(end = 4.dp)
+                                )
+                                Text(stringResource(R.string.button_browser_sign_in))
+                            }
+                            if (browserCookies.isNotEmpty()) {
+                                Icon(
+                                    imageVector = Icons.Default.CheckCircle,
+                                    contentDescription = stringResource(R.string.label_auth_browser_signed_in),
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                        if (browserCookies.isNotEmpty()) {
+                            Text(
+                                text = stringResource(R.string.label_auth_browser_signed_in),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+                }
+
                 // Bearer token field
                 AnimatedVisibility(visible = authType == AuthType.BEARER) {
                     OutlinedTextField(
@@ -445,10 +583,15 @@ fun ServerDialog(
             Button(
                 onClick = {
                     if (validate()) {
+                        val effectivePort = if (authType == AuthType.BROWSER && !showPortField) {
+                            443
+                        } else {
+                            port.trim().toInt()
+                        }
                         onSave(
                             name.trim(),
                             hostname.trim(),
-                            port.trim().toInt(),
+                            effectivePort,
                             authType,
                             buildCredentials()
                         )

--- a/app/src/main/java/sh/hnet/comfychair/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/screens/LoginScreen.kt
@@ -1,7 +1,12 @@
 package sh.hnet.comfychair.ui.screens
 
+import android.app.Activity
 import android.content.Intent
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import sh.hnet.comfychair.WebViewAuthActivity
+import sh.hnet.comfychair.connection.ConnectionFailure
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -73,6 +78,20 @@ enum class ConnectionState {
 /**
  * Login screen composable - handles connection to ComfyUI server
  */
+/**
+ * Build a server URL with proper protocol detection.
+ * Port 443 → HTTPS, port 80 → HTTP, port 8188 → HTTP (ComfyUI default).
+ * Standard ports (80/443) omitted from URL. Others included.
+ */
+private fun buildServerUrl(hostname: String, port: Int): String {
+    return when (port) {
+        443 -> "https://$hostname"
+        80 -> "http://$hostname"
+        8188 -> "http://$hostname:8188"
+        else -> "https://$hostname:$port"
+    }
+}
+
 @Composable
 fun LoginScreen() {
     val context = LocalContext.current
@@ -104,6 +123,39 @@ fun LoginScreen() {
     var showDeleteConfirmation by remember { mutableStateOf(false) }
     var showOfflinePrompt by remember { mutableStateOf(false) }
     var offlinePromptServer by remember { mutableStateOf<Server?>(null) }
+    var showBrowserReauthPrompt by remember { mutableStateOf(false) }
+    var browserReauthServer by remember { mutableStateOf<Server?>(null) }
+    // Set to a server to trigger attemptConnection via LaunchedEffect (avoids forward-ref)
+    var pendingBrowserConnect by remember { mutableStateOf<Server?>(null) }
+
+    // Browser auth WebView launcher — used when session expired / first connect
+    val webViewAuthLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val server = browserReauthServer ?: return@rememberLauncherForActivityResult
+            val cookies = result.data?.getStringExtra(WebViewAuthActivity.EXTRA_COOKIES) ?: ""
+            val authDomain = result.data?.getStringExtra(WebViewAuthActivity.EXTRA_AUTH_DOMAIN) ?: ""
+            val authDomainCookies = result.data?.getStringExtra(WebViewAuthActivity.EXTRA_AUTH_DOMAIN_COOKIES) ?: ""
+            if (cookies.isNotEmpty()) {
+                credentialStorage.saveCredentials(
+                    server.id,
+                    sh.hnet.comfychair.model.AuthCredentials.Cookie(
+                        cookies = cookies,
+                        authDomain = authDomain,
+                        authDomainCookies = authDomainCookies
+                    )
+                )
+                showBrowserReauthPrompt = false
+                browserReauthServer = null
+                connectionState = ConnectionState.IDLE
+                pendingBrowserConnect = server  // triggers LaunchedEffect below
+            }
+        } else {
+            showBrowserReauthPrompt = false
+            browserReauthServer = null
+        }
+    }
 
     // String resources
     val warningSelfSigned = stringResource(R.string.warning_self_signed_cert)
@@ -115,6 +167,17 @@ fun LoginScreen() {
         warningMessage = null
 
         scope.launch {
+            // For browser auth with no stored cookies, open WebView immediately
+            if (server.authType == sh.hnet.comfychair.model.AuthType.BROWSER &&
+                !credentialStorage.hasCredentials(server.id, server.authType)) {
+                connectionState = ConnectionState.IDLE
+                val serverUrl = buildServerUrl(server.hostname, server.port)
+                browserReauthServer = server
+                val intent = WebViewAuthActivity.createIntent(context, serverUrl, server.hostname)
+                webViewAuthLauncher.launch(intent)
+                return@launch
+            }
+
             // Load credentials for the server
             val credentials = credentialStorage.getCredentials(server.id, server.authType)
 
@@ -174,20 +237,38 @@ fun LoginScreen() {
             } else {
                 connectionState = ConnectionState.FAILED
 
-                // Check if offline cache exists - offer offline mode
-                if (ConnectionManager.hasOfflineCache(context, server.id)) {
+                // For browser auth failures (expired session), offer re-auth via browser
+                if (server.authType == sh.hnet.comfychair.model.AuthType.BROWSER) {
+                    delay(500)
+                    connectionState = ConnectionState.IDLE
+                    val serverUrl = buildServerUrl(server.hostname, server.port)
+                    browserReauthServer = server
+                    val intent = WebViewAuthActivity.createIntent(context, serverUrl, server.hostname)
+                    webViewAuthLauncher.launch(intent)
+                } else if (ConnectionManager.hasOfflineCache(context, server.id)) {
+                    // Check if offline cache exists - offer offline mode
                     offlinePromptServer = server
                     showOfflinePrompt = true
+                    delay(2000)
+                    connectionState = ConnectionState.IDLE
                 } else {
                     // No cache available, just show error Toast
                     errorMessage?.let { msg ->
                         Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
                     }
+                    delay(2000)
+                    connectionState = ConnectionState.IDLE
                 }
-
-                delay(2000)
-                connectionState = ConnectionState.IDLE
             }
+        }
+    }
+
+    // Trigger attemptConnection after WebView auth completes (avoids forward-reference issue)
+    LaunchedEffect(pendingBrowserConnect) {
+        pendingBrowserConnect?.let { server ->
+            pendingBrowserConnect = null
+            delay(200)
+            attemptConnection(server)
         }
     }
 

--- a/app/src/main/java/sh/hnet/comfychair/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/screens/LoginScreen.kt
@@ -9,12 +9,14 @@ import sh.hnet.comfychair.WebViewAuthActivity
 import sh.hnet.comfychair.connection.ConnectionFailure
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
@@ -22,6 +24,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -114,6 +117,11 @@ fun LoginScreen() {
     }
     var connectionState by remember { mutableStateOf(ConnectionState.IDLE) }
     var warningMessage by remember { mutableStateOf<String?>(null) }
+    var showCertDialog by remember { mutableStateOf(false) }
+    var pendingCertIssue by remember { mutableStateOf(CertificateIssue.NONE) }
+    var pendingCertServer by remember { mutableStateOf<Server?>(null) }
+    var pendingCertClient by remember { mutableStateOf<ComfyUIClient?>(null) }
+    var pendingCertProtocol by remember { mutableStateOf<String?>(null) }
     var comfyUIClient by remember { mutableStateOf<ComfyUIClient?>(null) }
     var hasAutoConnected by remember { mutableStateOf(false) }
 
@@ -199,25 +207,22 @@ fun LoginScreen() {
             val (success, errorMessage, certIssue) = result
 
             if (success) {
-                connectionState = ConnectionState.CONNECTED
+                val detectedProtocol = client.getWorkingProtocol() ?: "http"
 
-                // Handle certificate warnings
-                val navigateDelay = when (certIssue) {
-                    CertificateIssue.SELF_SIGNED -> {
-                        warningMessage = warningSelfSigned
-                        1000L
-                    }
-                    CertificateIssue.UNKNOWN_CA -> {
-                        warningMessage = warningUnknownCa
-                        1000L
-                    }
-                    CertificateIssue.NONE -> 500L
+                // Handle certificate issues
+                if (certIssue != CertificateIssue.NONE && !server.trustCert) {
+                    // Cert issue and user hasn't trusted this server — ask
+                    connectionState = ConnectionState.CONNECTED
+                    pendingCertIssue = certIssue
+                    pendingCertServer = server
+                    pendingCertClient = client
+                    pendingCertProtocol = detectedProtocol
+                    showCertDialog = true
+                    return@launch
                 }
 
-                delay(navigateDelay)
-
-                // Establish connection via ConnectionManager
-                val detectedProtocol = client.getWorkingProtocol() ?: "http"
+                connectionState = ConnectionState.CONNECTED
+                delay(500L)
 
                 // Save selected server
                 serverStorage.setSelectedServerId(server.id)
@@ -476,6 +481,107 @@ fun LoginScreen() {
             dismissButton = {
                 OutlinedButton(onClick = { showOfflinePrompt = false }) {
                     Text(stringResource(R.string.button_offline_prompt_dismiss))
+                }
+            }
+        )
+    }
+
+    // Certificate warning dialog
+    if (showCertDialog && pendingCertServer != null) {
+        var rememberChoice by remember { mutableStateOf(false) }
+
+        val certTitle = when (pendingCertIssue) {
+            CertificateIssue.SELF_SIGNED -> "Self-Signed Certificate"
+            CertificateIssue.UNKNOWN_CA -> "Unknown Certificate Authority"
+            else -> "Certificate Warning"
+        }
+        val certMessage = when (pendingCertIssue) {
+            CertificateIssue.SELF_SIGNED ->
+                "The server is using a self-signed certificate. " +
+                "This is common for local servers but means the connection " +
+                "cannot be verified by a trusted authority.\n\n" +
+                "Do you want to continue connecting?"
+            CertificateIssue.UNKNOWN_CA ->
+                "The server's certificate was issued by an unrecognized " +
+                "certificate authority. This could mean the CA is not in " +
+                "your device's trust store.\n\n" +
+                "Do you want to continue connecting?"
+            else -> "There is a certificate issue. Continue?"
+        }
+
+        AlertDialog(
+            onDismissRequest = {
+                showCertDialog = false
+                connectionState = ConnectionState.IDLE
+                pendingCertServer = null
+                pendingCertClient = null
+                pendingCertProtocol = null
+            },
+            title = { Text(certTitle) },
+            text = {
+                Column {
+                    Text(certMessage)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.clickable { rememberChoice = !rememberChoice }
+                    ) {
+                        Checkbox(
+                            checked = rememberChoice,
+                            onCheckedChange = { rememberChoice = it }
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            "Remember for this server",
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showCertDialog = false
+                        val server = pendingCertServer!!
+                        val protocol = pendingCertProtocol ?: "http"
+                        pendingCertServer = null
+                        pendingCertClient = null
+                        pendingCertProtocol = null
+
+                        scope.launch {
+                            // Save trust preference if checked
+                            if (rememberChoice) {
+                                serverStorage.updateServer(server.copy(trustCert = true))
+                            }
+
+                            serverStorage.setSelectedServerId(server.id)
+                            ConnectionManager.connect(
+                                context = context.applicationContext,
+                                serverId = server.id,
+                                hostname = server.hostname,
+                                port = server.port,
+                                protocol = protocol,
+                                authType = server.authType,
+                                credentials = credentialStorage.getCredentials(server.id, server.authType)
+                            )
+                            onConnected()
+                        }
+                    }
+                ) {
+                    Text("Connect Anyway")
+                }
+            },
+            dismissButton = {
+                OutlinedButton(
+                    onClick = {
+                        showCertDialog = false
+                        connectionState = ConnectionState.IDLE
+                        pendingCertServer = null
+                        pendingCertClient = null
+                        pendingCertProtocol = null
+                    }
+                ) {
+                    Text("Cancel")
                 }
             }
         )

--- a/app/src/main/java/sh/hnet/comfychair/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/screens/LoginScreen.kt
@@ -561,10 +561,12 @@ fun LoginScreen() {
                                 hostname = server.hostname,
                                 port = server.port,
                                 protocol = protocol,
-                                authType = server.authType,
                                 credentials = credentialStorage.getCredentials(server.id, server.authType)
                             )
-                            onConnected()
+
+                            // Navigate to main activity
+                            val intent = Intent(context, MainContainerActivity::class.java)
+                            context.startActivity(intent)
                         }
                     }
                 ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -632,4 +632,15 @@
 
     <!-- Metadata actions -->
     <string name="metadata_save_prompt">Save prompt to library</string>
+
+    <!-- Browser / SSO Auth -->
+    <string name="option_auth_type_browser">Browser / SSO</string>
+    <string name="label_auth_browser_hint">Opens a browser window to sign in via your SSO provider (e.g., Authentik). Cookies are captured automatically after login.</string>
+    <string name="button_browser_sign_in">Sign In</string>
+    <string name="label_auth_browser_signed_in">Signed in — cookies captured</string>
+    <string name="title_browser_auth">Sign In</string>
+    <string name="button_browser_auth_done">Done</string>
+    <string name="button_custom_port">Custom port</string>
+    <string name="message_session_expired">Your login session has expired. Please re-authenticate to continue.</string>
+    <string name="button_reauthenticate">Re-authenticate</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,9 @@
     <string name="msg_connection_lost">Unable to connect to the server after multiple attempts.</string>
     <string name="title_session_expired">Session Expired</string>
     <string name="msg_session_expired">Your session has expired. Please log in again.</string>
+    <string name="message_session_expired">Your browser authentication session has expired and automatic refresh failed. Please re-authenticate to continue.</string>
+    <string name="button_reauthenticate">Re-authenticate</string>
+    <string name="button_logout">Log Out</string>
     <string name="title_transfer_stalled">Transfer Stalled</string>
     <string name="msg_transfer_stalled">No data was transferred for 30 seconds. This may indicate a connection problem.</string>
     <string name="error_upload_stalled">Upload stalled</string>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -10,4 +10,7 @@
 
     <!-- Exclude connection settings (hostname/port) for security -->
     <exclude domain="sharedpref" path="ComfyChairPrefs.xml" />
+
+    <!-- Exclude EncryptedSharedPreferences — Keystore keys don't survive backup/restore -->
+    <exclude domain="sharedpref" path="ModelBrowserSecurePrefs.xml" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -11,6 +11,9 @@
 
         <!-- Exclude connection settings (hostname/port) for security -->
         <exclude domain="sharedpref" path="ComfyChairPrefs.xml" />
+
+        <!-- Exclude EncryptedSharedPreferences — Keystore keys don't survive restore -->
+        <exclude domain="sharedpref" path="ModelBrowserSecurePrefs.xml" />
     </cloud-backup>
 
     <!-- Device-to-device transfer configuration -->


### PR DESCRIPTION
Adds a new auth type that opens a WebView for login, captures session cookies, and injects them into API requests. Supports Authentik, Authelia, OAuth2-proxy, Cloudflare Access, and similar setups where a reverse proxy handles auth via browser redirects.

Changes:
- New AuthType.BROWSER and AuthCredentials.Cookie
- WebViewAuthActivity with auto-detection of completed auth flow
- Cookie storage via EncryptedSharedPreferences
- AuthInterceptor injects Cookie header
- ServerDialog: fourth auth type button with in-dialog sign-in
- LoginScreen: auto-opens WebView on first connect or expired session