### PR TITLE
Read samplers and schedulers from server instead of hardcoded list

### DIFF
--- a/app/src/main/java/sh/hnet/comfychair/connection/ConnectionManager.kt
+++ b/app/src/main/java/sh/hnet/comfychair/connection/ConnectionManager.kt
@@ -1030,7 +1030,24 @@ object ConnectionManager {
             latentUpscaleModels = nodeTypeRegistry.getOptionsForNodeInput(
                 "LatentUpscaleModelLoader",
                 TemplateKeyRegistry.getJsonKeyForPlaceholder("latent_upscale_model")
-            )
+            ),
+            // Samplers/schedulers from KSampler node — captures custom-node additions
+            samplers = nodeTypeRegistry.getOptionsForNodeInput(
+                "KSampler",
+                TemplateKeyRegistry.getJsonKeyForPlaceholder("sampler_name")
+            ).ifEmpty {
+                nodeTypeRegistry.getOptionsForField(
+                    TemplateKeyRegistry.getJsonKeyForPlaceholder("sampler_name")
+                )
+            },
+            schedulers = nodeTypeRegistry.getOptionsForNodeInput(
+                "KSampler",
+                TemplateKeyRegistry.getJsonKeyForPlaceholder("scheduler")
+            ).ifEmpty {
+                nodeTypeRegistry.getOptionsForField(
+                    TemplateKeyRegistry.getJsonKeyForPlaceholder("scheduler")
+                )
+            }
         )
     }
 }

--- a/app/src/main/java/sh/hnet/comfychair/connection/ModelCache.kt
+++ b/app/src/main/java/sh/hnet/comfychair/connection/ModelCache.kt
@@ -16,6 +16,10 @@ data class ModelCache(
     val upscaleMethods: List<String> = emptyList(),
     val textEncoders: List<String> = emptyList(),
     val latentUpscaleModels: List<String> = emptyList(),
+    /** Sampler names from server (includes custom-node samplers like res_multistep, etc.) */
+    val samplers: List<String> = emptyList(),
+    /** Scheduler names from server (includes custom-node schedulers like bong_tangent, etc.) */
+    val schedulers: List<String> = emptyList(),
     val isLoaded: Boolean = false,
     val isLoading: Boolean = false,
     val lastError: String? = null

--- a/app/src/main/java/sh/hnet/comfychair/ui/components/NodeAttributeSideSheet.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/components/NodeAttributeSideSheet.kt
@@ -453,9 +453,10 @@ private fun guessType(value: Any?): String {
  * Get default options for known field names when server definition is missing.
  */
 private fun getDefaultOptionsForField(fieldName: String): List<String>? {
+    val cache = ConnectionManager.modelCache.value
     return when (fieldName) {
-        "sampler_name" -> SamplerOptions.SAMPLERS
-        "scheduler" -> SamplerOptions.SCHEDULERS
+        "sampler_name" -> cache.samplers.ifEmpty { SamplerOptions.SAMPLERS }
+        "scheduler" -> cache.schedulers.ifEmpty { SamplerOptions.SCHEDULERS }
         else -> null
     }
 }

--- a/app/src/main/java/sh/hnet/comfychair/ui/components/config/BottomSheetConfigExtensions.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/components/config/BottomSheetConfigExtensions.kt
@@ -1,6 +1,7 @@
 package sh.hnet.comfychair.ui.components.config
 
 import sh.hnet.comfychair.R
+import sh.hnet.comfychair.connection.ConnectionManager
 import sh.hnet.comfychair.model.SamplerOptions
 import sh.hnet.comfychair.viewmodel.ImageToImageMode
 import sh.hnet.comfychair.viewmodel.ImageToImageUiState
@@ -557,13 +558,15 @@ private fun buildEditingModeParameterConfig(
         ),
         sampler = DropdownField(
             selectedValue = state.editingSampler,
-            options = SamplerOptions.SAMPLERS,
+            options = ConnectionManager.modelCache.value.samplers
+                .ifEmpty { SamplerOptions.SAMPLERS },
             onValueChange = callbacks.onEditingSamplerChange ?: noOpString,
             isVisible = caps.hasSamplerName
         ),
         scheduler = DropdownField(
             selectedValue = state.editingScheduler,
-            options = SamplerOptions.SCHEDULERS,
+            options = ConnectionManager.modelCache.value.schedulers
+                .ifEmpty { SamplerOptions.SCHEDULERS },
             onValueChange = callbacks.onEditingSchedulerChange ?: noOpString,
             isVisible = caps.hasScheduler
         ),

--- a/app/src/main/java/sh/hnet/comfychair/ui/components/config/BottomSheetConfigHelpers.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/components/config/BottomSheetConfigHelpers.kt
@@ -1,6 +1,7 @@
 package sh.hnet.comfychair.ui.components.config
 
 import sh.hnet.comfychair.R
+import sh.hnet.comfychair.connection.ConnectionManager
 import sh.hnet.comfychair.model.SamplerOptions
 
 /**
@@ -166,14 +167,16 @@ internal fun buildCommonParameterConfig(
 
         sampler = DropdownField(
             selectedValue = state.sampler,
-            options = SamplerOptions.SAMPLERS,
+            options = ConnectionManager.modelCache.value.samplers
+                .ifEmpty { SamplerOptions.SAMPLERS },
             onValueChange = callbacks.onSamplerChange ?: noOpString,
             isVisible = caps.hasSamplerName
         ),
 
         scheduler = DropdownField(
             selectedValue = state.scheduler,
-            options = SamplerOptions.SCHEDULERS,
+            options = ConnectionManager.modelCache.value.schedulers
+                .ifEmpty { SamplerOptions.SCHEDULERS },
             onValueChange = callbacks.onSchedulerChange ?: noOpString,
             isVisible = caps.hasScheduler
         ),


### PR DESCRIPTION
SamplerOptions contains a static list of samplers and schedulers. Custom nodes that add new ones (e.g. bong_tangent) never appear.

Pull them from the KSampler node definition in /object_info, which already gets fetched on connect. Falls back to the static list when server data hasn't loaded yet.

- Add samplers/schedulers to ModelCache
- Populate from KSampler in extractModelLists()
- Update BottomSheetConfigHelpers, BottomSheetConfigExtensions, and NodeAttributeSideSheet to use live lists