### PR TITLE
feat: hierarchical folder tree in model/lora dropdowns

### DIFF
--- a/app/src/main/java/sh/hnet/comfychair/ui/components/LoraChainEditor.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/components/LoraChainEditor.kt
@@ -36,7 +36,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import sh.hnet.comfychair.R
 import sh.hnet.comfychair.model.LoraSelection
+import sh.hnet.comfychair.ui.components.shared.HierarchicalTreeItems
 import sh.hnet.comfychair.ui.components.shared.ModelPathText
+import sh.hnet.comfychair.ui.components.shared.buildModelTree
+import sh.hnet.comfychair.ui.components.shared.folderPathOf
+import sh.hnet.comfychair.ui.components.shared.modelTreeHasFolders
 import java.util.Locale
 
 /**
@@ -118,6 +122,12 @@ private fun LoraEntryItem(
 ) {
     var expanded by remember { mutableStateOf(false) }
 
+    val tree = remember(availableLoras) { buildModelTree(availableLoras) }
+    val hasFolders = remember(tree) { modelTreeHasFolders(tree) }
+    var expandedPath by remember(lora.name) {
+        mutableStateOf(folderPathOf(lora.name))
+    }
+
     Column(
         modifier = Modifier.fillMaxWidth()
     ) {
@@ -136,7 +146,10 @@ private fun LoraEntryItem(
             // LoRA dropdown
             ExposedDropdownMenuBox(
                 expanded = expanded,
-                onExpandedChange = { expanded = it },
+                onExpandedChange = {
+                    expanded = it
+                    if (it) expandedPath = folderPathOf(lora.name)
+                },
                 modifier = Modifier.weight(1f)
             ) {
                 OutlinedTextField(
@@ -155,14 +168,29 @@ private fun LoraEntryItem(
                     expanded = expanded,
                     onDismissRequest = { expanded = false }
                 ) {
-                    availableLoras.forEach { option ->
-                        DropdownMenuItem(
-                            text = { ModelPathText(option) },
-                            onClick = {
-                                onNameChange(option)
+                    if (!hasFolders) {
+                        availableLoras.forEach { option ->
+                            DropdownMenuItem(
+                                text = { ModelPathText(option) },
+                                onClick = {
+                                    onNameChange(option)
+                                    expanded = false
+                                },
+                                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                            )
+                        }
+                    } else {
+                        HierarchicalTreeItems(
+                            node = tree,
+                            currentPath = "",
+                            expandedPath = expandedPath,
+                            selectedValue = lora.name,
+                            depth = 0,
+                            onExpandFolder = { expandedPath = it },
+                            onSelectModel = { path ->
+                                onNameChange(path)
                                 expanded = false
-                            },
-                            contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                            }
                         )
                     }
                 }

--- a/app/src/main/java/sh/hnet/comfychair/ui/components/NodeAttributeSideSheet.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/components/NodeAttributeSideSheet.kt
@@ -453,9 +453,10 @@ private fun guessType(value: Any?): String {
  * Get default options for known field names when server definition is missing.
  */
 private fun getDefaultOptionsForField(fieldName: String): List<String>? {
+    val cache = ConnectionManager.modelCache.value
     return when (fieldName) {
-        "sampler_name" -> SamplerOptions.SAMPLERS
-        "scheduler" -> SamplerOptions.SCHEDULERS
+        "sampler_name" -> cache.samplers.ifEmpty { SamplerOptions.SAMPLERS }
+        "scheduler" -> cache.schedulers.ifEmpty { SamplerOptions.SCHEDULERS }
         else -> null
     }
 }
@@ -475,10 +476,19 @@ private fun EnumEditor(
     var expanded by remember { mutableStateOf(false) }
     var tooltipExpanded by remember { mutableStateOf(false) }
 
+    val tree = remember(options) { sh.hnet.comfychair.ui.components.shared.buildModelTree(options) }
+    val hasFolders = remember(tree) { sh.hnet.comfychair.ui.components.shared.modelTreeHasFolders(tree) }
+    var expandedPath by remember(value) {
+        mutableStateOf(sh.hnet.comfychair.ui.components.shared.folderPathOf(value))
+    }
+
     Column {
         ExposedDropdownMenuBox(
             expanded = expanded,
-            onExpandedChange = { expanded = it }
+            onExpandedChange = {
+                expanded = it
+                if (it) expandedPath = sh.hnet.comfychair.ui.components.shared.folderPathOf(value)
+            }
         ) {
             OutlinedTextField(
                 value = value,
@@ -506,16 +516,31 @@ private fun EnumEditor(
                 expanded = expanded,
                 onDismissRequest = { expanded = false }
             ) {
-                options.forEach { option ->
-                    key(option) {
-                        DropdownMenuItem(
-                            text = { ModelPathText(option) },
-                            onClick = {
-                                onValueChange(option)
-                                expanded = false
-                            }
-                        )
+                if (!hasFolders) {
+                    options.forEach { option ->
+                        key(option) {
+                            DropdownMenuItem(
+                                text = { ModelPathText(option) },
+                                onClick = {
+                                    onValueChange(option)
+                                    expanded = false
+                                }
+                            )
+                        }
                     }
+                } else {
+                    sh.hnet.comfychair.ui.components.shared.HierarchicalTreeItems(
+                        node = tree,
+                        currentPath = "",
+                        expandedPath = expandedPath,
+                        selectedValue = value,
+                        depth = 0,
+                        onExpandFolder = { expandedPath = it },
+                        onSelectModel = { path ->
+                            onValueChange(path)
+                            expanded = false
+                        }
+                    )
                 }
             }
         }

--- a/app/src/main/java/sh/hnet/comfychair/ui/components/shared/HierarchicalDropdownMenu.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/components/shared/HierarchicalDropdownMenu.kt
@@ -1,0 +1,193 @@
+package sh.hnet.comfychair.ui.components.shared
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+/**
+ * A model tree node — either a folder containing children or a leaf model.
+ */
+data class ModelTreeNode(
+    val name: String,
+    val fullPath: String = "",
+    val children: MutableMap<String, ModelTreeNode> = mutableMapOf(),
+    val isFolder: Boolean = false
+)
+
+/**
+ * Build a tree from a flat list of model paths.
+ * Paths like "subfolder/model.safetensors" become folder nodes with leaf children.
+ */
+fun buildModelTree(options: List<String>): ModelTreeNode {
+    val root = ModelTreeNode(name = "", isFolder = true)
+    for (path in options) {
+        val parts = path.replace('\\', '/').split('/')
+        var current = root
+        for (i in parts.indices) {
+            val part = parts[i]
+            if (i == parts.lastIndex) {
+                current.children[part] = ModelTreeNode(
+                    name = part,
+                    fullPath = path,
+                    isFolder = false
+                )
+            } else {
+                current.children.getOrPut(part) {
+                    ModelTreeNode(name = part, isFolder = true)
+                }
+                current = current.children[part]!!
+            }
+        }
+    }
+    return root
+}
+
+/**
+ * Check if a tree has any folder nodes (i.e. needs hierarchical display).
+ */
+fun modelTreeHasFolders(tree: ModelTreeNode): Boolean =
+    tree.children.values.any { it.isFolder }
+
+/**
+ * Get the folder path of a model path.
+ * e.g. "illustrious/sub/model.safetensors" -> "illustrious/sub"
+ * Returns "" for root-level models.
+ */
+fun folderPathOf(modelPath: String): String {
+    val normalized = modelPath.replace('\\', '/')
+    val lastSlash = normalized.lastIndexOf('/')
+    return if (lastSlash > 0) normalized.substring(0, lastSlash) else ""
+}
+
+/**
+ * Render hierarchical tree items inside a dropdown menu.
+ * Call this inside an ExposedDropdownMenu or DropdownMenu block.
+ *
+ * @param node The tree node to render children of
+ * @param currentPath The path prefix for this level (empty for root)
+ * @param expandedPath The currently expanded folder path
+ * @param selectedValue The currently selected model's full path
+ * @param depth The nesting depth (for indentation)
+ * @param onExpandFolder Called when a folder is clicked
+ * @param onSelectModel Called when a model is selected
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HierarchicalTreeItems(
+    node: ModelTreeNode,
+    currentPath: String,
+    expandedPath: String,
+    selectedValue: String,
+    depth: Int,
+    onExpandFolder: (String) -> Unit,
+    onSelectModel: (String) -> Unit
+) {
+    val sortedChildren = remember(node.children) {
+        node.children.values.sortedWith(
+            compareByDescending<ModelTreeNode> { it.isFolder }
+                .thenBy { it.name.lowercase() }
+        )
+    }
+
+    for (child in sortedChildren) {
+        val childPath = if (currentPath.isEmpty()) child.name else "$currentPath/${child.name}"
+
+        if (child.isFolder) {
+            val isExpanded = expandedPath == childPath || expandedPath.startsWith("$childPath/")
+
+            DropdownMenuItem(
+                text = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(
+                            imageVector = if (isExpanded) Icons.Default.FolderOpen
+                            else Icons.Default.Folder,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(20.dp)
+                                .padding(end = 4.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Text(
+                            text = child.name,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Icon(
+                            imageVector = if (isExpanded)
+                                Icons.Default.KeyboardArrowDown
+                            else
+                                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                },
+                onClick = {
+                    if (isExpanded) {
+                        onExpandFolder(if (currentPath.isEmpty()) "" else currentPath)
+                    } else {
+                        onExpandFolder(childPath)
+                    }
+                },
+                modifier = Modifier.padding(start = (depth * 16).dp),
+                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+            )
+
+            if (isExpanded) {
+                HierarchicalTreeItems(
+                    node = child,
+                    currentPath = childPath,
+                    expandedPath = expandedPath,
+                    selectedValue = selectedValue,
+                    depth = depth + 1,
+                    onExpandFolder = onExpandFolder,
+                    onSelectModel = onSelectModel
+                )
+            }
+        } else {
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        text = child.name,
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        color = if (child.fullPath == selectedValue)
+                            MaterialTheme.colorScheme.primary
+                        else
+                            MaterialTheme.colorScheme.onSurface
+                    )
+                },
+                onClick = { onSelectModel(child.fullPath) },
+                modifier = Modifier.padding(start = (depth * 16).dp),
+                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+            )
+        }
+    }
+}

--- a/app/src/main/java/sh/hnet/comfychair/ui/components/shared/ModelDropdown.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/components/shared/ModelDropdown.kt
@@ -17,7 +17,15 @@ import androidx.compose.ui.Modifier
 
 /**
  * A dropdown component for selecting models (checkpoints, UNETs, VAEs, CLIPs, etc.)
- * Uses ModelPathText to display paths with dimmed directory portions.
+ *
+ * Automatically switches between flat and hierarchical (folder tree) display
+ * based on whether any option contains path separators.
+ *
+ * Hierarchical behavior:
+ * - Folders shown first, then root-level models
+ * - Clicking a folder expands it (collapses siblings at same level)
+ * - Re-opening auto-expands to the currently selected model's folder
+ * - Selected model is highlighted in primary color
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -30,9 +38,22 @@ fun ModelDropdown(
 ) {
     var expanded by remember { mutableStateOf(false) }
 
+    val tree = remember(options) { buildModelTree(options) }
+    val hasFolders = remember(tree) { modelTreeHasFolders(tree) }
+
+    // Track expanded folder path; auto-expand to selected model's folder
+    var expandedPath by remember(selectedValue) {
+        mutableStateOf(folderPathOf(selectedValue))
+    }
+
     ExposedDropdownMenuBox(
         expanded = expanded,
-        onExpandedChange = { expanded = it },
+        onExpandedChange = {
+            expanded = it
+            if (it) {
+                expandedPath = folderPathOf(selectedValue)
+            }
+        },
         modifier = modifier
     ) {
         OutlinedTextField(
@@ -51,14 +72,31 @@ fun ModelDropdown(
             expanded = expanded,
             onDismissRequest = { expanded = false }
         ) {
-            options.forEach { option ->
-                DropdownMenuItem(
-                    text = { ModelPathText(option) },
-                    onClick = {
-                        onValueChange(option)
+            if (!hasFolders) {
+                // Flat list (original behavior)
+                options.forEach { option ->
+                    DropdownMenuItem(
+                        text = { ModelPathText(option) },
+                        onClick = {
+                            onValueChange(option)
+                            expanded = false
+                        },
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                    )
+                }
+            } else {
+                // Hierarchical folder tree
+                HierarchicalTreeItems(
+                    node = tree,
+                    currentPath = "",
+                    expandedPath = expandedPath,
+                    selectedValue = selectedValue,
+                    depth = 0,
+                    onExpandFolder = { expandedPath = it },
+                    onSelectModel = { path ->
+                        onValueChange(path)
                         expanded = false
-                    },
-                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                    }
                 )
             }
         }


### PR DESCRIPTION
Model and LoRA dropdowns now show folder structure instead of a flat list. Folders appear first with folder icons, clicking a folder expands it and collapses siblings at the same level.

- Auto-expands to the currently selected model's folder when opened
- Selected model highlighted in primary color
- Falls back to flat list when no subfolders exist
- Applied to ModelDropdown, LoraChainEditor, and EnumEditor
- Shared HierarchicalTreeItems composable for consistent behavior