### PR TITLE
Change the Lora weight control to a Stepper, and support -99 to 99

### DIFF
--- a/app/src/main/java/sh/hnet/comfychair/model/LoraSelection.kt
+++ b/app/src/main/java/sh/hnet/comfychair/model/LoraSelection.kt
@@ -14,8 +14,8 @@ data class LoraSelection(
     val strength: Float = DEFAULT_STRENGTH
 ) {
     companion object {
-        const val MIN_STRENGTH = 0.0f
-        const val MAX_STRENGTH = 2.0f
+        const val MIN_STRENGTH = -99.0f
+        const val MAX_STRENGTH = 99.0f
         const val DEFAULT_STRENGTH = 1.0f
         const val MAX_CHAIN_LENGTH = 5
 

--- a/app/src/main/java/sh/hnet/comfychair/ui/components/LoraChainEditor.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/components/LoraChainEditor.kt
@@ -38,6 +38,8 @@ import sh.hnet.comfychair.R
 import sh.hnet.comfychair.model.LoraSelection
 import sh.hnet.comfychair.ui.components.shared.HierarchicalTreeItems
 import sh.hnet.comfychair.ui.components.shared.ModelPathText
+import sh.hnet.comfychair.ui.components.shared.NumericStepperField
+import sh.hnet.comfychair.ui.components.shared.NumericStepperFieldFloat
 import sh.hnet.comfychair.ui.components.shared.buildModelTree
 import sh.hnet.comfychair.ui.components.shared.folderPathOf
 import sh.hnet.comfychair.ui.components.shared.modelTreeHasFolders
@@ -209,23 +211,15 @@ private fun LoraEntryItem(
                 .padding(start = 24.dp, end = 48.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = stringResource(R.string.label_lora_strength),
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.width(64.dp)
-            )
-
-            Slider(
+            NumericStepperFieldFloat(
                 value = lora.strength,
                 onValueChange = onStrengthChange,
-                valueRange = LoraSelection.MIN_STRENGTH..LoraSelection.MAX_STRENGTH,
+                label = stringResource(R.string.label_lora_strength),
+                min = LoraSelection.MIN_STRENGTH,
+                max = LoraSelection.MAX_STRENGTH,
+                step = 0.1f,
+                decimalPlaces = 1,
                 modifier = Modifier.weight(1f)
-            )
-
-            Text(
-                text = String.format(Locale.US, "%.1f", lora.strength),
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.width(32.dp)
             )
         }
     }

--- a/app/src/main/java/sh/hnet/comfychair/ui/components/shared/NumericStepperFieldFloat.kt
+++ b/app/src/main/java/sh/hnet/comfychair/ui/components/shared/NumericStepperFieldFloat.kt
@@ -1,0 +1,77 @@
+package sh.hnet.comfychair.ui.components.shared
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import sh.hnet.comfychair.R
+import java.util.Locale
+
+/**
+ * A numeric input field with increment/decrement stepper buttons inside the text field.
+ * Supports both integer and floating-point values with configurable step size.
+ *
+ * @param value The current value as a string
+ * @param onValueChange Callback when the value changes
+ * @param label The field label
+ * @param min Minimum allowed value
+ * @param max Maximum allowed value
+ * @param step Step size for increment/decrement
+ */
+@Composable
+fun NumericStepperFieldFloat(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    label: String,
+    min: Float,
+    max: Float,
+    step: Float,
+    decimalPlaces: Int = 0,
+    modifier: Modifier = Modifier
+) {
+    var currentValue by remember { mutableStateOf(value.toString()) };
+    NumericStepperField(
+        value = currentValue,
+        onValueChange = { newText ->
+            currentValue = newText;
+            newText.toFloatOrNull()?.let { rawFloat ->
+                if (rawFloat > max) {
+                    onValueChange(max);
+                    currentValue = max.toString();
+                    return@let;
+                } else if (rawFloat < min) {
+                    onValueChange(min);
+                    currentValue = min.toString();
+                    return@let;
+                }
+                onValueChange(rawFloat);
+            }
+        },
+        label = label,
+        min = min,
+        max = max,
+        step = step,
+        decimalPlaces = decimalPlaces,
+        modifier = modifier
+    )
+}


### PR DESCRIPTION
1. Added option to adjust Lora weight range from -99 to 99 #35 
2. NumericStepperFieldFloat control (internally implemented with NumericStepperField) is used to bind float type data
3. Replaced Slider control with NumericStepperFieldFloat to handle a larger range of values
